### PR TITLE
fallback to double when a big integer is encountered.

### DIFF
--- a/JSON.h
+++ b/JSON.h
@@ -1367,8 +1367,13 @@ namespace giri {
                 else {
                     if( !exp_str.empty() )
                         Number = std::stol( val ) * std::pow( 10, exp );
-                    else
-                        Number = std::stol( val );
+                    else {
+                        try {
+                            Number = std::stoll( val );
+                        } catch (...) {
+                            Number = std::stod( val );
+                        }
+                    }
                 }
                 return Number;
             }


### PR DESCRIPTION
When parsing JSON generated by languages with built-in big integers (Python, Mathematica, etc), exceptions would occur.

With this PR, when a big integer is encountered, it will fall back to use `double`. This behavior is similar to JS (although it does not have integer types and has `BigInt`): 

![image](https://github.com/user-attachments/assets/0b37713d-3851-4689-9a1d-9a302b3b1eb8)
